### PR TITLE
Add Postgres adapter.

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,7 +4,8 @@
     "adapter": [
         "snowflake",
         "redshift",
-        "spark"
+        "spark",
+        "postgres"
     ],
     "target_schema": "dev",
     "run_git_init": [

--- a/{{cookiecutter.project_slug}}/.config/profiles.yml
+++ b/{{cookiecutter.project_slug}}/.config/profiles.yml
@@ -79,3 +79,32 @@ default:
         # search_path: public # optional, not recommended
         # sslmode: [optional, set the sslmode used to connect to the database (in case this parameter is set, will look for ca in ~/.postgresql/root.crt)]
         {%- endif %}
+
+        {%- if cookiecutter.adapter == "postgres" %}
+
+        # Set the DBT_DATABASE in your CI
+        database: {% raw %}"{{ env_var('DBT_DATABASE') }}"{% endraw %}
+        schema: {{ cookiecutter.target_schema }}
+
+        # Set variable DBT_USER in your CI
+        user: {% raw %}"{{ env_var('DBT_USER') }}"{% endraw %}
+
+        # Set variable DBT_PASSWORD in your CI
+        password: {% raw %}"{{ env_var('DBT_PASSWORD') }}"{% endraw %}
+
+        # Additional Postgres options
+        # Find out more about Postgres config options here:
+        # https://docs.getdbt.com/reference/warehouse-profiles/postgres-profile
+
+        # Set variable DBT_POSTGRES_HOST in your CI
+        host: {% raw %}"{{ env_var('DBT_POSTGRES_HOST') }}"{% endraw %}
+        port: 5432
+
+        keepalives_idle: 0 # default 0, indicating the system default.
+        connect_timeout: 10 # default 10 seconds
+        
+        # search_path: [optional, override the default postgres search_path]
+        # role: [optional, set the role dbt assumes when executing queries]
+        # sslmode: [optional, set the sslmode used to connect to the database]
+
+        {%- endif %}

--- a/{{cookiecutter.project_slug}}/.config/user_profiles.yml
+++ b/{{cookiecutter.project_slug}}/.config/user_profiles.yml
@@ -70,3 +70,24 @@ default:
         # search_path: public # optional, not recommended
         # sslmode: [optional, set the sslmode used to connect to the database (in case this parameter is set, will look for ca in ~/.postgresql/root.crt)]
         {%- endif %}
+
+        {%- if cookiecutter.adapter == "postgres" %}
+        # Additional Postgres options
+        # Find out more about Postgres config options here:
+        # https://docs.getdbt.com/reference/warehouse-profiles/postgres-profile
+
+        # Replace the information below with your specific information
+        dbname: your_database_name
+        schema: {{ cookiecutter.target_schema }}
+        user: your_database_user_name
+        password: your_database_password
+
+        host: localhost # your Postgres host name
+        port: 5432
+        keepalives_idle: 0 # default 0, indicating the system default. See below
+        connect_timeout: 10 # default 10 seconds
+        # search_path: [optional, override the default postgres search_path]
+        # role: [optional, set the role dbt assumes when executing queries]
+        # sslmode: [optional, set the sslmode used to connect to the database]
+
+        {%- endif %}

--- a/{{cookiecutter.project_slug}}/.config/user_profiles.yml
+++ b/{{cookiecutter.project_slug}}/.config/user_profiles.yml
@@ -84,7 +84,7 @@ default:
 
         host: localhost # your Postgres host name
         port: 5432
-        keepalives_idle: 0 # default 0, indicating the system default. See below
+        keepalives_idle: 0 # default 0, indicating the system default.
         connect_timeout: 10 # default 10 seconds
         # search_path: [optional, override the default postgres search_path]
         # role: [optional, set the role dbt assumes when executing queries]


### PR DESCRIPTION
Adds Postgres options to `.config/profiles.yml` and `.config/user_profiles.yml`, and lists it as an adapter option in `cookiecutter.json`.

Addresses the issue mentioned in #10 , regarding to Postgres specifically.